### PR TITLE
Fix SetTextAppearance call in BottomBarBadge constructor

### DIFF
--- a/src/bottom-navigation-bar/BottomBarBadge.cs
+++ b/src/bottom-navigation-bar/BottomBarBadge.cs
@@ -145,7 +145,7 @@ namespace BottomNavigationBar
 
             LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WrapContent, ViewGroup.LayoutParams.WrapContent);
             Gravity = GravityFlags.Center;
-            SetTextAppearance(Resource.Style.BB_BottomBarBadge_Text);
+            SetTextAppearance(context, Resource.Style.BB_BottomBarBadge_Text);
 
             int three = MiscUtils.DpToPixel(context, 3);
             ShapeDrawable backgroundCircle = BadgeCircle.Make(three * 3, backgroundColor);


### PR DESCRIPTION
Fix #9 by using the deprecated, pre-API 23 SetTextAppearance(Context, int) method.