### PR TITLE
Revert dependency versions back to support Xamarin.Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BottomNavigationBar
-<img src="https://raw.githubusercontent.com/pocheshire/BottomNavigationBar/master/scrolling_demo.gif" width="30%" /> <img src="https://raw.githubusercontent.com/pocheshire/BottomNavigationBar/master/demo_shifting.gif" width="30%" /> <img src="https://raw.githubusercontent.com/pocheshire/BottomNavigationBar/master/screenshot_tablet.png" width="33%" /> 
+<img src="https://raw.githubusercontent.com/pocheshire/BottomNavigationBar/master/src/bottom-navigation-bar/demo1.gif" width="30%" /> <img src="https://raw.githubusercontent.com/pocheshire/BottomNavigationBar/master/src/bottom-navigation-bar/demo_shifting.gif" width="30%" /> 
 
 **[How to contribute](https://github.com/pocheshire/BottomNavigationBar/blob/master/README.md#contributions)**
 

--- a/src/bottom-navigation-bar/BottomNavigationBar.csproj
+++ b/src/bottom-navigation-bar/BottomNavigationBar.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -17,6 +17,8 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ReleaseVersion>1.4.0.1</ReleaseVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,23 +51,29 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>packages\Xamarin.Android.Support.v4.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
-      <HintPath>packages\Xamarin.Android.Support.v7.RecyclerView.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.Design, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
-      <HintPath>packages\Xamarin.Android.Support.Vector.Drawable.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.v4, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
-      <HintPath>packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.v7.AppCompat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
-      <HintPath>packages\Xamarin.Android.Support.v7.AppCompat.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.v7.RecyclerView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Xamarin.Android.Support.Design">
-      <HintPath>packages\Xamarin.Android.Support.Design.23.4.0.1\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+    <Reference Include="Xamarin.Android.Support.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -103,17 +111,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\src\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\src\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <ItemGroup>
-    <Folder Include="Resources\values\" />
-    <Folder Include="Resources\layout\" />
-    <Folder Include="Resources\drawable\" />
-    <Folder Include="Resources\values-sw600dp\" />
-    <Folder Include="Scrollswetness\" />
-    <Folder Include="Adapters\" />
-    <Folder Include="Listeners\" />
-    <Folder Include="Utils\" />
-    <Folder Include="Enums\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <AndroidResource Include="Resources\values\attrs.xml" />
     <AndroidResource Include="Resources\values\bools.xml" />
@@ -129,5 +127,11 @@
     <AndroidResource Include="Resources\values-sw600dp\bools.xml" />
     <AndroidResource Include="Resources\values\dimens.xml" />
   </ItemGroup>
-  <Import Project="packages\Xamarin.Android.Support.Vector.Drawable.23.4.0.1\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('packages\Xamarin.Android.Support.Vector.Drawable.23.4.0.1\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets'))" />
+  </Target>
 </Project>

--- a/src/bottom-navigation-bar/BottomNavigationBar.nuspec
+++ b/src/bottom-navigation-bar/BottomNavigationBar.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BottomNavigationBar</id>
-    <version>1.4.0.1</version>
+    <version>1.4.0.2</version>
     <title>BottomNavigationBar</title>
     <authors>pocheshire</authors>
     <owners>pocheshire</owners>
@@ -15,12 +15,12 @@
     <tags>XamarinAndroid Xamarin Android BottomNavigationBar Bottom Navigation Bar</tags>
 	<dependencies>
       <dependency id="Newtonsoft.Json" version="9.0.1" />
-	  <dependency id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.4.0.1" />
-	  <dependency id="Xamarin.Android.Support.Design" version="23.4.0.1" />
-	  <dependency id="Xamarin.Android.Support.v4" version="23.4.0.1" />
-	  <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.4.0.1" />
-	  <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="23.4.0.1" />
-	  <dependency id="Xamarin.Android.Support.Vector.Drawable" version="23.4.0.1" />
+	  <dependency id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" />
+	  <dependency id="Xamarin.Android.Support.Design" version="23.3.0" />
+	  <dependency id="Xamarin.Android.Support.v4" version="23.3.0" />
+	  <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" />
+	  <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" />
+	  <dependency id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/bottom-navigation-bar/packages.config
+++ b/src/bottom-navigation-bar/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.4.0.1" targetFramework="monoandroid70" />
-  <package id="Xamarin.Android.Support.Design" version="23.4.0.1" targetFramework="monoandroid70" />
-  <package id="Xamarin.Android.Support.v4" version="23.4.0.1" targetFramework="monoandroid70" />
-  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.4.0.1" targetFramework="monoandroid70" />
-  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.4.0.1" targetFramework="monoandroid70" />
-  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.4.0.1" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid70" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid70" />
 </packages>


### PR DESCRIPTION
It's a fix for #24 and image sources in the readme file.

I've built it locally and there were no bugs or unwanted behavior so I think it's ok.